### PR TITLE
Update sequelize: 6.18.0 → 6.19.0 (minor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3498,9 +3498,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -3550,9 +3550,9 @@
       }
     },
     "sequelize": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.18.0.tgz",
-      "integrity": "sha512-x8TW8ovqG8ljZq0Uow1mtMq44hSKPefWEC590R9IWgF2dajEHvKJJpXo1FiRPfj6spOHWOnmOs1Xbb1JPG3Ifg==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.19.0.tgz",
+      "integrity": "sha512-B3oGIdpYBERDjRDm74h7Ky67f6ZLcmBXOA7HscYObiOSo4pD7VBc9mtm44wNV7unc0uk8I1d30nbZBTQCE377A==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "nocache": "^2.1.0",
     "pg": "^8.7.3",
     "pg-hstore": "^2.3.4",
-    "sequelize": "^6.18.0",
+    "sequelize": "^6.19.0",
     "sequelize-querystring-converter": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### What changed?

#### ✳️ sequelize (6.18.0 → 6.19.0)